### PR TITLE
Support unicode characters

### DIFF
--- a/enasearch/cli.py
+++ b/enasearch/cli.py
@@ -43,6 +43,7 @@ def print_complex_field_dict(d):
 
 def print_display(results, display):
     """Print the results given the choosen display"""
+    results = results.encode("utf-8")
     if display == 'xml':
         print(dicttoxml(results))
     elif display == 'fasta' or display == 'fastq':


### PR DESCRIPTION
The following two commands work just fine:

```
enasearch retrieve_run_report --accession PRJNA473989 --file results.txt
enasearch retrieve_run_report --accession PRJNA473989
```

But the following gives an exception
```
$ enasearch retrieve_run_report --accession PRJNA473989 > /dev/null
Traceback (most recent call last):
  File "/path/to/bin/enasearch", line 6, in <module>
    from enasearch.__main__ import main
  File "/path/to/lib/python2.7/site-packages/enasearch/__main__.py", line 6, in <module>
    cli.cli()
  File "/path/to/lib/python2.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/path/to/lib/python2.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/path/to/lib/python2.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/path/to/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/path/to/lib/python2.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/path/to/lib/python2.7/site-packages/enasearch/cli.py", line 20, in handle_exception
    raise click.ClickException(e)
  File "/path/to/lib/python2.7/site-packages/click/exceptions.py", line 23, in __init__
    ctor_msg = ctor_msg.encode("utf-8")
AttributeError: 'exceptions.UnicodeEncodeError' object has no attribute 'encode'
```

This is because the run report has a Unicode character